### PR TITLE
Dont skip clang

### DIFF
--- a/continuous-integration/linux/build.sh
+++ b/continuous-integration/linux/build.sh
@@ -6,7 +6,6 @@ SOURCE_DIR="$ROOT_DIR/source"
 BUILD_ROOT_DIR="$ROOT_DIR/build/ci"
 
 
-#TODO 16.04 default pcl is too old. See issue #43
 source /etc/os-release || exit $?
 if [[ "$VERSION_ID" == "16.04" ]]; then
     OS_SPECIFIC_OPTIONS="-DUSE_PCL=OFF -DUSE_EIGEN3=OFF -DUSE_OPENCV=OFF"

--- a/continuous-integration/linux/build.sh
+++ b/continuous-integration/linux/build.sh
@@ -5,13 +5,6 @@ ROOT_DIR=$(realpath "$SCRIPT_DIR/../..")
 SOURCE_DIR="$ROOT_DIR/source"
 BUILD_ROOT_DIR="$ROOT_DIR/build/ci"
 
-#There's a C++11 compatibility bug in the Zivid API which makes it fail on
-#older versions of Clang, such as the default Clang 3.8.2 on Ubuntu 16.04.
-#An internal Zivid issue to fix this has been logged. When that issue has
-#been fixed, this entire option should be removed.
-if [[ "$1" == "--skip-clang" ]]; then
-    SKIP_CLANG=true
-fi
 
 #TODO 16.04 default pcl is too old. See issue #43
 source /etc/os-release || exit $?
@@ -48,7 +41,5 @@ function build()
     cmake --build . || exit $?
 }
 
-if [[ ! "$SKIP_CLANG" ]]; then
-    build clang++ clang || exit $?
-fi
+build clang++ clang || exit $?
 build g++ gcc || exit $?


### PR DESCRIPTION
As of Zivid 2.0 we don't need to skip clang on Ubuntu 16.04. Also remove an outdated TODO.