### PR TITLE
Remove the need to enter \n to return EXIT_FAILURE

### DIFF
--- a/source/Applications/Advanced/CaptureUndistortRGB/CaptureUndistortRGB.cpp
+++ b/source/Applications/Advanced/CaptureUndistortRGB/CaptureUndistortRGB.cpp
@@ -209,9 +209,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Advanced/CreateDepthMap/CreateDepthMap.cpp
+++ b/source/Applications/Advanced/CreateDepthMap/CreateDepthMap.cpp
@@ -149,9 +149,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Advanced/Downsample/Downsample.cpp
+++ b/source/Applications/Advanced/Downsample/Downsample.cpp
@@ -52,9 +52,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Advanced/HandEyeCalibration/HandEyeCalibration/HandEyeCalibration.cpp
+++ b/source/Applications/Advanced/HandEyeCalibration/HandEyeCalibration/HandEyeCalibration.cpp
@@ -147,10 +147,8 @@ int main()
     {
         std::cerr << "\nError: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 
     return EXIT_SUCCESS;

--- a/source/Applications/Advanced/HandEyeCalibration/PoseConversions/PoseConversions.cpp
+++ b/source/Applications/Advanced/HandEyeCalibration/PoseConversions/PoseConversions.cpp
@@ -255,9 +255,7 @@ int main()
     {
         std::cerr << "Error: " << e.what() << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Advanced/HandEyeCalibration/UtilizeEyeInHandCalibration/UtilizeEyeInHandCalibration.cpp
+++ b/source/Applications/Advanced/HandEyeCalibration/UtilizeEyeInHandCalibration/UtilizeEyeInHandCalibration.cpp
@@ -179,9 +179,7 @@ int main()
     {
         std::cerr << "Error: " << e.what() << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Advanced/MultiCamera/MultiCameraCalibration/MultiCameraCalibration.cpp
+++ b/source/Applications/Advanced/MultiCamera/MultiCameraCalibration/MultiCameraCalibration.cpp
@@ -99,9 +99,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Advanced/MultiCamera/MultiCameraCalibrationFromZDF/MultiCameraCalibrationFromZDF.cpp
+++ b/source/Applications/Advanced/MultiCamera/MultiCameraCalibrationFromZDF/MultiCameraCalibrationFromZDF.cpp
@@ -111,9 +111,7 @@ int main(int argc, char **argv)
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Advanced/MultiCamera/StitchByTransformation/StitchByTransformation.cpp
+++ b/source/Applications/Advanced/MultiCamera/StitchByTransformation/StitchByTransformation.cpp
@@ -219,9 +219,7 @@ int main(int argc, char **argv)
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Advanced/MultiCamera/StitchByTransformationFromZDF/StitchByTransformationFromZDF.cpp
+++ b/source/Applications/Advanced/MultiCamera/StitchByTransformationFromZDF/StitchByTransformationFromZDF.cpp
@@ -204,9 +204,7 @@ int main(int argc, char **argv)
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Basic/FileFormats/ReadIterateZDF/ReadIterateZDF.cpp
+++ b/source/Applications/Basic/FileFormats/ReadIterateZDF/ReadIterateZDF.cpp
@@ -53,9 +53,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Basic/Visualization/CaptureFromFileCameraVis3D/CaptureFromFileCameraVis3D.cpp
+++ b/source/Applications/Basic/Visualization/CaptureFromFileCameraVis3D/CaptureFromFileCameraVis3D.cpp
@@ -48,9 +48,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Basic/Visualization/CaptureVis3D/CaptureVis3D.cpp
+++ b/source/Applications/Basic/Visualization/CaptureVis3D/CaptureVis3D.cpp
@@ -38,9 +38,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Basic/Visualization/CaptureWritePCLVis3D/CaptureWritePCLVis3D.cpp
+++ b/source/Applications/Basic/Visualization/CaptureWritePCLVis3D/CaptureWritePCLVis3D.cpp
@@ -83,9 +83,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Applications/Basic/Visualization/ReadPCLVis3D/ReadPCLVis3D.cpp
+++ b/source/Applications/Basic/Visualization/ReadPCLVis3D/ReadPCLVis3D.cpp
@@ -44,9 +44,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Camera/Advanced/CaptureHDRLoop/CaptureHDRLoop.cpp
+++ b/source/Camera/Advanced/CaptureHDRLoop/CaptureHDRLoop.cpp
@@ -40,9 +40,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Camera/Basic/Capture/Capture.cpp
+++ b/source/Camera/Basic/Capture/Capture.cpp
@@ -35,9 +35,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Camera/Basic/Capture2D/Capture2D.cpp
+++ b/source/Camera/Basic/Capture2D/Capture2D.cpp
@@ -49,9 +49,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Camera/Basic/CaptureAssistant/CaptureAssistant.cpp
+++ b/source/Camera/Basic/CaptureAssistant/CaptureAssistant.cpp
@@ -46,9 +46,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Camera/Basic/CaptureFromFileCamera/CaptureFromFileCamera.cpp
+++ b/source/Camera/Basic/CaptureFromFileCamera/CaptureFromFileCamera.cpp
@@ -40,9 +40,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Camera/Basic/CaptureHDR/CaptureHDR.cpp
+++ b/source/Camera/Basic/CaptureHDR/CaptureHDR.cpp
@@ -38,9 +38,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Camera/Basic/CaptureHDRCompleteSettings/CaptureHDRCompleteSettings.cpp
+++ b/source/Camera/Basic/CaptureHDRCompleteSettings/CaptureHDRCompleteSettings.cpp
@@ -74,9 +74,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Camera/Basic/CaptureWithSettingsFromYML/CaptureWithSettingsFromYML.cpp
+++ b/source/Camera/Basic/CaptureWithSettingsFromYML/CaptureWithSettingsFromYML.cpp
@@ -32,9 +32,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Camera/InfoUtilOther/CameraUserData/CameraUserData.cpp
+++ b/source/Camera/InfoUtilOther/CameraUserData/CameraUserData.cpp
@@ -88,9 +88,7 @@ int main(int argc, char **argv)
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Camera/InfoUtilOther/FirmwareUpdater/FirmwareUpdater.cpp
+++ b/source/Camera/InfoUtilOther/FirmwareUpdater/FirmwareUpdater.cpp
@@ -47,9 +47,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Camera/InfoUtilOther/GetCameraIntrinsics/GetCameraIntrinsics.cpp
+++ b/source/Camera/InfoUtilOther/GetCameraIntrinsics/GetCameraIntrinsics.cpp
@@ -61,9 +61,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }

--- a/source/Camera/InfoUtilOther/ZividBenchmark/ZividBenchmark.cpp
+++ b/source/Camera/InfoUtilOther/ZividBenchmark/ZividBenchmark.cpp
@@ -530,9 +530,7 @@ int main()
     {
         std::cerr << "Error: " << Zivid::toString(e) << std::endl;
         std::cout << "Press enter to exit." << std::endl;
-        if(std::cin.get() == '\n')
-        {
-            return EXIT_FAILURE;
-        }
+        std::cin.get();
+        return EXIT_FAILURE;
     }
 }


### PR DESCRIPTION
Change exception handling to always return EXIT_FAILURE, when handling exception. 
Before EXIT_FAILURE was only returned if one enters '\n' after an exception catch 
