### PR TITLE
Add samples showing in-field verification and correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ There are two main categories of samples: **Camera** and **Applications**. The s
     - [**GetCameraIntrinsics**][GetCameraIntrinsics-url] - Read intrinsic parameters from the Zivid camera.
     - [**FirmwareUpdater**][FirmwareUpdater-url] - Update firmware on the Zivid camera.
     - [**ZividBenchmark**][ZividBenchmark-url] - Benchmark the Zivid camera.
+  - **Maintenance**
+    - [**VerifyCameraInField**][VerifyCameraInField-url] - Check the dimension trueness of a Zivid camera.
+    - [**CorrectCameraInField**][CorrectCameraInField-url] - Correct the dimension trueness of a Zivid camera.
 
 - **Applications**
   - **Basic**
@@ -153,6 +156,8 @@ Tip: If your build hangs, try to increase the memory available to Docker.
 [GetCameraIntrinsics-url]: source/Camera/InfoUtilOther/GetCameraIntrinsics/GetCameraIntrinsics.cpp
 [FirmwareUpdater-url]: source/Camera/InfoUtilOther/FirmwareUpdater/FirmwareUpdater.cpp
 [ZividBenchmark-url]: source/Camera/InfoUtilOther/ZividBenchmark/ZividBenchmark.cpp
+[VerifyCameraInField-url]: source/Camera/Maintenance/VerifyCameraInField/VerifyCameraInField.cpp
+[CorrectCameraInField-url]: source/Camera/Maintenance/CorrectCameraInField/CorrectCameraInField.cpp
 [CaptureFromFileCameraVis3D-url]: source/Applications/Basic/Visualization/CaptureFromFileCameraVis3D/CaptureFromFileCameraVis3D.cpp
 [CaptureVis3D-url]: source/Applications/Basic/Visualization/CaptureVis3D/CaptureVis3D.cpp
 [CaptureWritePCLVis3D-url]: source/Applications/Basic/Visualization/CaptureWritePCLVis3D/CaptureWritePCLVis3D.cpp

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -24,6 +24,8 @@ set(SAMPLES
     Camera/InfoUtilOther/GetCameraIntrinsics
     Camera/InfoUtilOther/FirmwareUpdater
     Camera/InfoUtilOther/ZividBenchmark
+    Camera/Maintenance/VerifyCameraInField
+    Camera/Maintenance/CorrectCameraInField
     Applications/Basic/Visualization/CaptureFromFileCameraVis3D
     Applications/Basic/Visualization/CaptureVis3D
     Applications/Basic/Visualization/ReadPCLVis3D

--- a/source/Camera/Maintenance/CorrectCameraInField/CorrectCameraInField.cpp
+++ b/source/Camera/Maintenance/CorrectCameraInField/CorrectCameraInField.cpp
@@ -1,0 +1,120 @@
+/*
+This example shows how to perform In-field correction. This involves gathering data from
+a compatible calibration board at several distances, calculating an updated camera
+correction, and optionally saving that new correction to the camera.
+
+The correction will persist on the camera even though the camera is power-cycled or
+connected to a different PC. After saving a correction, it will automatically be used any
+time that camera captures a new point cloud.
+*/
+
+#include <Zivid/Zivid.h>
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+    bool yesNoPrompt(const std::string &question)
+    {
+        while(true)
+        {
+            std::string response;
+            std::cout << question << ": y/n " << std::endl;
+            std::cin >> response;
+
+            if(std::cin.fail() || response == "n" || response == "N")
+            {
+                return false;
+            }
+            if(response == "y" || response == "Y")
+            {
+                return true;
+            }
+            std::cout << "Invalid response. Please respond with either 'y' or 'n'." << std::endl;
+        }
+    }
+
+    std::vector<Zivid::Experimental::Calibration::InfieldCorrectionInput> collectDataset(Zivid::Camera &camera)
+    {
+        std::vector<Zivid::Experimental::Calibration::InfieldCorrectionInput> dataset;
+        std::cout << "Please point the camera at a Zivid in-field calibration board. " << std::endl;
+
+        const std::string printLine = "------------------------------------------------------------------------";
+        while(true)
+        {
+            std::cout << printLine << std::endl;
+            if(yesNoPrompt("Capture (y) or finish (n)?"))
+            {
+                std::cout << "Capturing calibration board" << std::endl;
+                const auto detectionResult = Zivid::Experimental::Calibration::detectFeaturePoints(camera);
+                const auto input = Zivid::Experimental::Calibration::InfieldCorrectionInput{ detectionResult };
+
+                if(input.valid())
+                {
+                    dataset.emplace_back(input);
+                    std::cout << "Valid measurement at: " << input.detectionResult().centroid() << std::endl;
+                }
+                else
+                {
+                    std::cout << "****INVALID****" << std::endl;
+                    std::cout << "Feedback: " << input.statusDescription() << std::endl;
+                }
+                std::cout << printLine << std::endl;
+            }
+            else
+            {
+                std::cout << "End of capturing stage." << std::endl;
+                std::cout << printLine << std::endl;
+                break;
+            }
+            std::cout << "You have collected " << dataset.size() << " valid measurements so far." << std::endl;
+        }
+        return dataset;
+    }
+
+} // namespace
+
+int main()
+{
+    try
+    {
+        Zivid::Application zivid;
+        std::cout << "Connecting to camera" << std::endl;
+        auto camera = zivid.connectCamera();
+
+        // Gather data
+        const auto dataset = collectDataset(camera);
+
+        // Calculate in-field correction
+        std::cout << "Collected " << dataset.size() << " valid measurements." << std::endl;
+        std::cout << "Calculating new camera correction..." << std::endl;
+        const auto correction = Zivid::Experimental::Calibration::computeCameraCorrection(dataset);
+        const auto accuracyEstimate = correction.accuracyEstimate();
+        std::cout
+            << "If written to the camera, this correction can be expected to yield a dimension accuracy of "
+            << std::fixed << std::setprecision(2) << 100.0F * accuracyEstimate.dimensionAccuracy()
+            << "% or better in the range of z=[" << static_cast<int>(std::round(accuracyEstimate.zMin())) << ","
+            << static_cast<int>(std::round(accuracyEstimate.zMax()))
+            << "] across the full FOV. Accuracy close to where the correction data was collected is likely better."
+            << std::endl;
+
+        // Optionally save to camera
+        if(yesNoPrompt("Save to camera?"))
+        {
+            std::cout << "Writing camera correction..." << std::endl;
+            Zivid::Experimental::Calibration::writeCameraCorrection(camera, correction);
+            std::cout << "Success" << std::endl;
+        }
+    }
+    catch(const std::exception &e)
+    {
+        std::cerr << "Error: " << Zivid::toString(e) << std::endl;
+        std::cout << "Press enter to exit." << std::endl;
+        std::cin.get();
+        return EXIT_FAILURE;
+    }
+}

--- a/source/Camera/Maintenance/VerifyCameraInField/VerifyCameraInField.cpp
+++ b/source/Camera/Maintenance/VerifyCameraInField/VerifyCameraInField.cpp
@@ -1,0 +1,59 @@
+/*
+This example shows how to verify the local dimension trueness of a camera.
+If the trueness is much worse than expected, the camera may have been damaged by
+shock in shipping in handling. If so, look at the CorrectCameraInField sample.
+*/
+
+#include <Zivid/Zivid.h>
+
+#include <iomanip>
+#include <iostream>
+
+int main()
+{
+    try
+    {
+        Zivid::Application zivid;
+
+        std::cout << "Connecting to camera" << std::endl;
+        auto camera = zivid.connectCamera();
+
+        // For convenience, print the timestamp of the latest correction
+        if(Zivid::Experimental::Calibration::hasCameraCorrection(camera))
+        {
+            const auto timestamp = Zivid::Experimental::Calibration::cameraCorrectionTimestamp(camera);
+            const auto time = std::chrono::system_clock::to_time_t(timestamp);
+            std::cout << "Timestamp of current camera correction: " << std::put_time(std::gmtime(&time), "%FT%TZ")
+                      << std::endl;
+        }
+        else
+        {
+            std::cout << "This camera has no in-field correction written to it." << std::endl;
+        }
+
+        // Gather data
+        std::cout << "Capturing calibration board" << std::endl;
+        const auto detectionResult = Zivid::Experimental::Calibration::detectFeaturePoints(camera);
+
+        // Prepare data and check that it is appropriate for in-field verification
+        const auto input = Zivid::Experimental::Calibration::InfieldCorrectionInput{ detectionResult };
+        if(!input.valid())
+        {
+            throw std::runtime_error("Capture not valid for in-field verification! Feedback: "
+                                     + input.statusDescription());
+        }
+
+        // Show results
+        std::cout << "Successful measurement at " << detectionResult.centroid() << std::endl;
+        const auto verification = Zivid::Experimental::Calibration::verifyCamera(input);
+        std::cout << "Estimated dimension trueness at measured position: " << std::setprecision(2) << std::fixed
+                  << verification.localDimensionTrueness() * 100.0F << "%" << std::endl;
+    }
+    catch(const std::exception &e)
+    {
+        std::cerr << "Error: " << Zivid::toString(e) << std::endl;
+        std::cout << "Press enter to exit." << std::endl;
+        std::cin.get();
+        return EXIT_FAILURE;
+    }
+}


### PR DESCRIPTION
This commit adds the following two samples:
- VerifyCameraTrueness
- CorrectCameraTrueness

Their purpose is to demonstrate the most important parts of the
experimental "in-field correction" API introduced in SDK 2.2.