### PR TITLE
Add Engine to list of settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ There are two main categories of samples: **Camera** and **Applications**. The s
 ## Instructions
 
 1. [**Install Zivid Software**](https://zivid.atlassian.net/wiki/spaces/ZividKB/pages/59080712/Zivid+Software+Installation).
-Note: The samples require Zivid SDK v2 (minor version 2.1 or newer).
+Note: The samples require Zivid SDK v2 (minor version 2.2 or newer).
 
 2. [**Download Zivid Sample Data**](https://zivid.atlassian.net/wiki/spaces/ZividKB/pages/450363393/Sample+Data).
 

--- a/source/Camera/Basic/CaptureHDRCompleteSettings/CaptureHDRCompleteSettings.cpp
+++ b/source/Camera/Basic/CaptureHDRCompleteSettings/CaptureHDRCompleteSettings.cpp
@@ -21,6 +21,7 @@ int main()
 
         std::cout << "Configuring global processing settings:" << std::endl;
         Zivid::Settings settings{
+            Zivid::Settings::Experimental::Engine::phase,
             Zivid::Settings::Processing::Filters::Smoothing::Gaussian::Enabled::yes,
             Zivid::Settings::Processing::Filters::Smoothing::Gaussian::Sigma{ 1.5 },
             Zivid::Settings::Processing::Filters::Noise::Removal::Enabled::yes,


### PR DESCRIPTION
Add engine to the list of settings in captureHDRCompleteSettings. 

Add line in sample discription that engine setting requires SDK v2.2 or newer