### PR TITLE
Use settings based on which camera is connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There are two main categories of samples: **Camera** and **Applications**. The s
     - [**Capture**][Capture-url] - Capture point clouds, with color, from the Zivid camera.
     - [**Capture2D**][Capture2D-url] - Capture 2D images from the Zivid camera.
     - [**CaptureAssistant**][CaptureAssistant-url] - Use Capture Assistant to capture point clouds, with color, from the Zivid camera.
-    - [**CaptureFromFileCamera**][CaptureFromFileCamera-url] - Capture point clouds, with color, from the Zivid file camera.
+    - [**CaptureFromFileCamera**][CaptureFromFileCamera-url] - Capture point clouds, with color, from the Zivid file camera. Currently supported by Zivid One.
     - [**CaptureWithSettingsFromYML**][CaptureWithSettingsFromYML-url] - Capture point clouds, with color, from the Zivid camera, with settings from YML file.
     - [**CaptureHDR**][CaptureHDR-url] - Capture HDR point clouds, with color, from the Zivid camera.
     - [**CaptureHDRCompleteSettings**][CaptureHDRCompleteSettings-url] - Capture point clouds, with color, from the Zivid camera with fully configured settings.
@@ -43,7 +43,7 @@ There are two main categories of samples: **Camera** and **Applications**. The s
 - **Applications**
   - **Basic**
     - **Visualization**
-      - [**CaptureFromFileCameraVis3D**][CaptureFromFileCameraVis3D-url] - Capture point clouds, with color, from the virtual Zivid camera, and visualize it.
+      - [**CaptureFromFileCameraVis3D**][CaptureFromFileCameraVis3D-url] - Capture point clouds, with color, from the virtual Zivid camera, and visualize it. Currently supported by Zivid One.
       - [**CaptureVis3D**][CaptureVis3D-url] - Capture point clouds, with color, from the Zivid camera, and visualize it.
       - [**CaptureWritePCLVis3D**][CaptureWritePCLVis3D-url] - Capture point clouds, with color, from the Zivid camera, save it to PCD file format, and visualize it.
         - **Dependencies:**

--- a/source/Camera/Advanced/CaptureHDRLoop/CaptureHDRLoop.cpp
+++ b/source/Camera/Advanced/CaptureHDRLoop/CaptureHDRLoop.cpp
@@ -18,11 +18,13 @@ int main()
         std::cout << "Connecting to camera" << std::endl;
         auto camera = zivid.connectCamera();
 
+        const auto cameraModel = camera.info().modelName().toString().substr(0, 9);
         const size_t captures = 3;
         for(size_t i = 1; i <= captures; i++)
         {
             std::stringstream settingsFile;
-            settingsFile << std::string(ZIVID_SAMPLE_DATA_DIR) + "/Settings/Settings0" << i << ".yml";
+            settingsFile << std::string(ZIVID_SAMPLE_DATA_DIR) + "/Settings/" << cameraModel << "/Settings0" << i
+                         << ".yml";
             std::cout << "Configuring settings from file: " << settingsFile.str() << ":" << std::endl;
             const auto settings = Zivid::Settings(settingsFile.str());
             std::cout << settings << std::endl;

--- a/source/Camera/Basic/CaptureHDR/CaptureHDR.cpp
+++ b/source/Camera/Basic/CaptureHDR/CaptureHDR.cpp
@@ -18,7 +18,7 @@ int main()
 
         std::cout << "Configuring settings" << std::endl;
         Zivid::Settings settings;
-        for(const auto aperture : { 11.31, 5.66, 2.83 })
+        for(const auto aperture : { 9.57, 4.76, 2.59 })
         {
             std::cout << "Adding acquisition with aperture = " << aperture << std::endl;
             const auto acquisitionSettings = Zivid::Settings::Acquisition{

--- a/source/Camera/Basic/CaptureHDRCompleteSettings/CaptureHDRCompleteSettings.cpp
+++ b/source/Camera/Basic/CaptureHDRCompleteSettings/CaptureHDRCompleteSettings.cpp
@@ -10,6 +10,29 @@ this example is to demonstrate how to configure all the settings.
 
 #include <iostream>
 
+namespace
+{
+    std::tuple<std::vector<double>, std::vector<double>, std::vector<size_t>> getExposureValues(
+        const Zivid::Camera &camera)
+    {
+        if(camera.info().modelName().toString().substr(0, 9) == "Zivid One")
+        {
+            const std::vector<double> aperture{ 8.0, 4.0, 4.0 };
+            const std::vector<double> gain{ 1.0, 1.0, 2.0 };
+            const std::vector<size_t> exposureTime{ 10000, 10000, 40000 };
+            return std::make_tuple(aperture, gain, exposureTime);
+        }
+        if(camera.info().modelName().toString().substr(0, 9) == "Zivid Two")
+        {
+            const std::vector<double> aperture{ 5.66, 2.38, 1.8 };
+            const std::vector<double> gain{ 1.0, 1.0, 1.0 };
+            const std::vector<size_t> exposureTime{ 1677, 5000, 100000 };
+            return std::make_tuple(aperture, gain, exposureTime);
+        }
+        throw std::invalid_argument("Unknown camera model");
+    }
+} // namespace
+
 int main()
 {
     try
@@ -44,9 +67,10 @@ int main()
         std::cout << baseAcquisition << std::endl;
 
         std::cout << "Configuring acquisition settings different for all HDR acquisitions" << std::endl;
-        const std::vector<double> aperture{ 8.0, 4.0, 4.0 };
-        const std::vector<double> gain{ 1.0, 1.0, 2.0 };
-        const std::vector<size_t> exposureTime{ 10000, 10000, 40000 };
+        auto exposureValues = getExposureValues(camera);
+        const std::vector<double> aperture = std::get<0>(exposureValues);
+        const std::vector<double> gain = std::get<1>(exposureValues);
+        const std::vector<size_t> exposureTime = std::get<2>(exposureValues);
         for(size_t i = 0; i < aperture.size(); ++i)
         {
             std::cout << "Acquisition " << i + 1 << ":" << std::endl;

--- a/source/Camera/Basic/CaptureWithSettingsFromYML/CaptureWithSettingsFromYML.cpp
+++ b/source/Camera/Basic/CaptureWithSettingsFromYML/CaptureWithSettingsFromYML.cpp
@@ -18,7 +18,8 @@ int main()
         auto camera = zivid.connectCamera();
 
         std::cout << "Creating settings from file" << std::endl;
-        const auto settingsFile = std::string(ZIVID_SAMPLE_DATA_DIR) + "/Settings/Settings01.yml";
+        std::string cameraModel = camera.info().modelName().toString().substr(0, 9);
+        const auto settingsFile = std::string(ZIVID_SAMPLE_DATA_DIR) + "/Settings/" + cameraModel + "/Settings01.yml";
         const auto settings = Zivid::Settings(settingsFile);
 
         std::cout << "Capturing frame" << std::endl;


### PR DESCRIPTION
Add logic to check if Zivid One or Zivid Two is connected and use settings
accordingly.
This commit requires an update of SAMPLE_DATA to run the samples that
read settings from file.