### PR TITLE
Clang tidy ignores

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >
   -cppcoreguidelines-pro-type-union-access,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -llvmlibc-*,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -llvmlibc-*,
   -cppcoreguidelines-pro-type-reinterpret-cast,
+  -hicpp-signed-bitwise,
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >
   -readability-magic-numbers,
   -cppcoreguidelines-pro-type-union-access,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -llvmlibc-*,
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/source/Applications/Advanced/CaptureUndistortRGB/CaptureUndistortRGB.cpp
+++ b/source/Applications/Advanced/CaptureUndistortRGB/CaptureUndistortRGB.cpp
@@ -118,8 +118,8 @@ namespace
 
     CameraIntrinsicsCV reformatCameraIntrinsics(const Zivid::CameraIntrinsics &cameraIntrinsics)
     {
-        cv::Mat distortionCoefficients(1, 5, CV_64FC1, cv::Scalar(0)); // NOLINT(hicpp-signed-bitwise)
-        cv::Mat cameraMatrix(3, 3, CV_64FC1, cv::Scalar(0));           // NOLINT(hicpp-signed-bitwise)
+        cv::Mat distortionCoefficients(1, 5, CV_64FC1, cv::Scalar(0));
+        cv::Mat cameraMatrix(3, 3, CV_64FC1, cv::Scalar(0));
 
         distortionCoefficients.at<double>(0, 0) = cameraIntrinsics.distortion().k1().value();
         distortionCoefficients.at<double>(0, 1) = cameraIntrinsics.distortion().k2().value();

--- a/source/Applications/Advanced/CreateDepthMap/CreateDepthMap.cpp
+++ b/source/Applications/Advanced/CreateDepthMap/CreateDepthMap.cpp
@@ -54,7 +54,7 @@ namespace
 
     cv::Mat pointCloudToCvZ(const Zivid::PointCloud &pointCloud)
     {
-        cv::Mat z(pointCloud.height(), pointCloud.width(), CV_8UC1, cv::Scalar(0)); // NOLINT(hicpp-signed-bitwise)
+        cv::Mat z(pointCloud.height(), pointCloud.width(), CV_8UC1, cv::Scalar(0));
         const auto points = pointCloud.copyPointsZ();
 
         // Getting min and max values for X, Y, Z images
@@ -102,9 +102,9 @@ namespace
 
     cv::Mat pointCloudToCvBGR(const Zivid::PointCloud &pointCloud)
     {
-        auto rgb = cv::Mat(pointCloud.height(), pointCloud.width(), CV_8UC4); // NOLINT(hicpp-signed-bitwise)
+        auto rgb = cv::Mat(pointCloud.height(), pointCloud.width(), CV_8UC4);
         pointCloud.copyData(reinterpret_cast<Zivid::ColorRGBA *>(rgb.data));
-        auto bgr = cv::Mat(pointCloud.height(), pointCloud.width(), CV_8UC4); // NOLINT(hicpp-signed-bitwise)
+        auto bgr = cv::Mat(pointCloud.height(), pointCloud.width(), CV_8UC4);
         cv::cvtColor(rgb, bgr, cv::COLOR_BGR2RGB);
 
         return bgr;

--- a/source/Applications/Advanced/CreateDepthMap/CreateDepthMap.cpp
+++ b/source/Applications/Advanced/CreateDepthMap/CreateDepthMap.cpp
@@ -103,8 +103,7 @@ namespace
     cv::Mat pointCloudToCvBGR(const Zivid::PointCloud &pointCloud)
     {
         auto rgb = cv::Mat(pointCloud.height(), pointCloud.width(), CV_8UC4); // NOLINT(hicpp-signed-bitwise)
-        pointCloud.copyData(
-            reinterpret_cast<Zivid::ColorRGBA *>(rgb.data)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        pointCloud.copyData(reinterpret_cast<Zivid::ColorRGBA *>(rgb.data));
         auto bgr = cv::Mat(pointCloud.height(), pointCloud.width(), CV_8UC4); // NOLINT(hicpp-signed-bitwise)
         cv::cvtColor(rgb, bgr, cv::COLOR_BGR2RGB);
 

--- a/source/Applications/Advanced/HandEyeCalibration/PoseConversions/PoseConversions.cpp
+++ b/source/Applications/Advanced/HandEyeCalibration/PoseConversions/PoseConversions.cpp
@@ -158,7 +158,6 @@ namespace
 
     cv::Mat eigenToCv(const Eigen::MatrixXd &eigenMat)
     {
-        // NOLINTNEXTLINE(hicpp-signed-bitwise)
         cv::Mat cvMat(static_cast<int>(eigenMat.rows()), static_cast<int>(eigenMat.cols()), CV_64FC1, cv::Scalar(0));
 
         cv::eigen2cv(eigenMat, cvMat);

--- a/source/Applications/Advanced/MaskPointCloud/MaskPointCloud.cpp
+++ b/source/Applications/Advanced/MaskPointCloud/MaskPointCloud.cpp
@@ -43,7 +43,7 @@ namespace
         }
 
         // Filling in OpenCV matrix with the cloud data
-        cv::Mat z(pointCloud.height, pointCloud.width, CV_8UC1, cv::Scalar(0)); // NOLINT(hicpp-signed-bitwise)
+        cv::Mat z(pointCloud.height, pointCloud.width, CV_8UC1, cv::Scalar(0));
         for(size_t i = 0; i < pointCloud.height; i++)
         {
             for(size_t j = 0; j < pointCloud.width; j++)

--- a/source/Applications/Advanced/TransformPointCloudViaArucoMarker/TransformPointCloudViaArucoMarker.cpp
+++ b/source/Applications/Advanced/TransformPointCloudViaArucoMarker/TransformPointCloudViaArucoMarker.cpp
@@ -224,9 +224,9 @@ namespace
 
     cv::Mat pointCloudToColorBGR(const Zivid::PointCloud &pointCloud)
     {
-        const auto rgb = cv::Mat(pointCloud.height(), pointCloud.width(), CV_8UC4); // NOLINT(hicpp-signed-bitwise)
+        const auto rgb = cv::Mat(pointCloud.height(), pointCloud.width(), CV_8UC4);
         pointCloud.copyData(reinterpret_cast<Zivid::ColorRGBA *>(rgb.data));
-        auto bgr = cv::Mat(pointCloud.height(), pointCloud.width(), CV_8UC4); // NOLINT(hicpp-signed-bitwise)
+        auto bgr = cv::Mat(pointCloud.height(), pointCloud.width(), CV_8UC4);
         cv::cvtColor(rgb, bgr, cv::COLOR_RGBA2BGR);
 
         return bgr;

--- a/source/Applications/Advanced/TransformPointCloudViaArucoMarker/TransformPointCloudViaArucoMarker.cpp
+++ b/source/Applications/Advanced/TransformPointCloudViaArucoMarker/TransformPointCloudViaArucoMarker.cpp
@@ -225,8 +225,7 @@ namespace
     cv::Mat pointCloudToColorBGR(const Zivid::PointCloud &pointCloud)
     {
         const auto rgb = cv::Mat(pointCloud.height(), pointCloud.width(), CV_8UC4); // NOLINT(hicpp-signed-bitwise)
-        pointCloud.copyData(
-            reinterpret_cast<Zivid::ColorRGBA *>(rgb.data)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        pointCloud.copyData(reinterpret_cast<Zivid::ColorRGBA *>(rgb.data));
         auto bgr = cv::Mat(pointCloud.height(), pointCloud.width(), CV_8UC4); // NOLINT(hicpp-signed-bitwise)
         cv::cvtColor(rgb, bgr, cv::COLOR_RGBA2BGR);
 


### PR DESCRIPTION
Ignore some commonly ignored warnings in .clang-tidy instead. See the individual commit messages.